### PR TITLE
Add Bootstrap-WTF Macros for Form Rendering

### DIFF
--- a/app/templates/bootstrap-wtf.html
+++ b/app/templates/bootstrap-wtf.html
@@ -1,0 +1,105 @@
+{#
+    Helper macros for rendering Flask-WTF forms with Bootstrap 5.
+    Based on examples from Flask-Bootstrap and adapted for Bootstrap 5.
+    #}
+    
+    {% macro render_field(field, form_type="basic", horizontal_columns=('lg', 2, 10), button_map={}) %} {# Removed **kwargs from definition #}
+        {# Renders a single form field with label, input, errors, and description. #}
+    
+        {# Determine field attributes, ensure class is appended not replaced #}
+        {# Jinja2 implicitly provides a 'kwargs' dictionary containing extra arguments passed to the macro call #}
+        {% set field_kwargs = kwargs.copy() %}
+        {% set current_class = field_kwargs.pop('class_', '') %}
+        {% set default_class = 'form-control' %}
+        {% if field.type == 'BooleanField' %}
+            {% set default_class = 'form-check-input' %}
+        {% elif field.type == 'RadioField' %}
+            {% set default_class = 'form-check-input' %}
+        {% elif field.type == 'SubmitField' %}
+            {% set default_class = 'btn ' + button_map.get(field.id, 'btn-primary') %}
+        {% elif field.type == 'FileField' %}
+             {# FileField might not need form-control, depends on styling #}
+             {% set default_class = 'form-control' %}
+        {% endif %}
+    
+        {# Add is-invalid class if field has errors #}
+        {% if field.errors %}
+            {% set default_class = default_class + ' is-invalid' %}
+        {% endif %}
+    
+        {# Correct way to update the 'class' key in the field_kwargs dictionary using 'do' #}
+        {% do field_kwargs.update({'class': default_class + ' ' + current_class}) %}
+    
+        {# Main field rendering logic #}
+        {% if field.widget.input_type == 'hidden' or field.id == 'csrf_token' %}
+            {{ field(**field_kwargs) }} {# Pass collected kwargs when calling the field object #}
+        {% elif field.type == 'BooleanField' %}
+            {# Use kwargs directly from the implicit context for div_class #}
+            <div class="form-check mb-3 {{ kwargs.get('div_class', '') }}">
+                {{ field(class_=field_kwargs['class'], **field_kwargs) }} {# Pass collected kwargs #}
+                {{ field.label(class="form-check-label") }}
+                {% if field.errors %}
+                    {% for error in field.errors %}
+                        <div class="invalid-feedback d-block">{{ error }}</div>
+                    {% endfor %}
+                {% endif %}
+                {% if field.description %}
+                    <small class="form-text text-muted">{{ field.description }}</small>
+                {% endif %}
+            </div>
+        {% elif field.type == 'RadioField' %}
+             <div class="mb-3 {{ kwargs.get('div_class', '') }}">
+                <label class="form-label">{{ field.label }}</label>
+                {% for subfield in field %}
+                <div class="form-check">
+                    {{ subfield(class_=field_kwargs['class'], **field_kwargs) }} {# Pass collected kwargs #}
+                    {{ subfield.label(class='form-check-label') }}
+                </div>
+                {% endfor %}
+                {% if field.errors %}
+                    {% for error in field.errors %}
+                        <div class="invalid-feedback d-block">{{ error }}</div>
+                    {% endfor %}
+                {% endif %}
+                {% if field.description %}
+                    <small class="form-text text-muted">{{ field.description }}</small>
+                {% endif %}
+            </div>
+        {% else %} {# Standard text, password, email, textarea, etc. #}
+            <div class="mb-3 {{ kwargs.get('div_class', '') }}">
+                {{ field.label(class="form-label") }}
+                {{ field(**field_kwargs) }} {# Pass collected kwargs #}
+                {% if field.errors %}
+                    {% for error in field.errors %}
+                        <div class="invalid-feedback d-block">{{ error }}</div>
+                    {% endfor %}
+                {% endif %}
+                {% if field.description %}
+                    <small class="form-text text-muted">{{ field.description }}</small>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endmacro %}
+    
+    {# Alias for simpler usage in templates #}
+    {% macro form_field(field) %} {# Removed **kwargs from definition #}
+      {{ render_field(field, **kwargs) }} {# Pass kwargs down to render_field implicitly #}
+    {% endmacro %}
+    
+    {# Macro to render the entire form structure (optional, often handled in template) #}
+    {% macro quick_form(form, action=request.full_path, method="post", extra_classes=None, role="form", enctype=None, id="", novalidate=False, render_kw={}) %}
+        <form {% if id %}id="{{id}}"{% endif %} action="{{action}}" method="{{method}}"
+            class="form {{ extra_classes }}"
+            role="{{role}}"
+            {% if enctype %}enctype="{{enctype}}"{% endif %}
+            {% if novalidate %}novalidate{% endif %}
+            {% if render_kw %} {{ render_kw|xmlattr }} {% endif %}>
+            {{ form.hidden_tag() }} {# Includes CSRF token #}
+            {% for field in form if not field.widget.input_type == 'hidden' and field.id != 'csrf_token' %}
+                {# Call render_field for each field; any extra args passed to quick_form are not automatically passed here #}
+                {{ render_field(field) }}
+            {% endfor %}
+            {# Typically, submit buttons are rendered explicitly in the template using form_field or render_field #}
+            {# e.g., {{ form_field(form.submit, class="btn btn-primary") }} #}
+        </form>
+    {% endmacro %}


### PR DESCRIPTION
This PR adds a reusable Jinja2 macro template file, bootstrap_wtf.html, that streamlines the rendering of Flask-WTF form fields using Bootstrap 5 styling