### PR TITLE
Remove Redundant Navigation Buttons from Analyze Page

### DIFF
--- a/app/templates/analyze.html
+++ b/app/templates/analyze.html
@@ -47,18 +47,4 @@
 
     </div>
 </div>
-
-<!-- Link to view user's own results -->
-<div class="row mt-4">
-    <div class="col-md-8 offset-md-2 text-center">
-        <p><a href="{{ url_for('main.results') }}" class="btn btn-info">View My Analysis Results</a></p>
-    </div>
-</div>
-
-<!-- Link to view results shared with the user -->
-<div class="row mt-2">
-    <div class="col-md-8 offset-md-2 text-center">
-        <p><a href="{{ url_for('main.shared_with_me') }}" class="btn btn-outline-secondary">View Results Shared With Me</a></p>
-    </div>
-</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
This PR removes redundant navigation buttons from the analyze.html page. The buttons were duplicating functionality already present in the main navigation bar, creating visual clutter and potentially confusing users.

## Changes
- Removed the "View My Analysis Results" button from the bottom of the analyze page
- Removed the "View Results Shared With Me" button from the bottom of the analyze page

## Motivation
The main navigation bar already contains "My Results" and "Shared With Me" links, making the additional buttons at the bottom of the analyze page unnecessary. This change improves the user interface by:
1. Eliminating redundancy in the interface
2. Maintaining a clear navigation structure
3. Reducing visual clutter on the analysis page

## Testing
- Verified that all navigation functionality remains accessible through the main navigation menu
- Confirmed the analyze page displays correctly with the buttons removed
- Ensured all routes and links continue to function properly

After:
- Cleaner analyze page without duplicate navigation options

## Related Issues
No specific issue ticket, part of ongoing UI/UX improvements to the selective sharing implementation.