### PR TITLE
Fix: Resolve UI element hover flicker on bottom edge approach

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -270,7 +270,8 @@ h1.display-5 {
 
 .navbar .nav-link:hover {
     color: white !important;
-    transform: translateY(-3px);
+    transform: scale(1.05); /* Adjust scale factor for desired "growth" */
+    transform-origin: center bottom; /* Scale from the bottom-center */
     box-shadow: var(--depth-shadow);
     animation: navLinkPulse 1.5s infinite;
 }
@@ -374,7 +375,9 @@ main.container {
 }
 
 .card:hover, .result:hover, .list-group-item:hover {
-    transform: translateY(-8px) scale(1.02);
+    /* transform: translateY(-8px) scale(1.02); */ /* Original transform */
+    transform: scale(1.05); /* Adjust scale factor (e.g., for ~10px upward growth on a 200px tall card) */
+    transform-origin: center bottom; /* Scale from the bottom-center */
     box-shadow: var(--depth-shadow-hover);
 }
 
@@ -449,7 +452,9 @@ textarea.form-control {
 }
 
 .btn-primary:hover {
-    transform: translateY(-3px) scale(1.05);
+    /* transform: translateY(-3px) scale(1.05); */ /* Original transform */
+    transform: scale(1.08); /* Adjust scale factor */
+    transform-origin: center bottom; /* Scale from the bottom-center */
     box-shadow: var(--depth-shadow);
 }
 
@@ -861,7 +866,9 @@ canvas#sentimentChart {
 }
 
 .report-card:hover {
-    transform: translateY(-10px) scale(1.02); /* Keep existing hover from general .card */
+    /* transform: translateY(-10px) scale(1.02); */ /* Original transform */
+    transform: scale(1.05); /* Adjust scale factor (e.g., for ~10px upward growth on a 200px tall card) */
+    transform-origin: center bottom; /* Scale from the bottom-center */
     box-shadow: var(--depth-shadow-hover);
 }
 
@@ -950,7 +957,9 @@ canvas#sentimentChart {
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
 }
 .btn-cyber-primary:hover, .btn-cyber-secondary:hover, .btn-cyber-outline:hover {
-    transform: translateY(-3px) scale(1.03); /* Consistent hover transform */
+    /* transform: translateY(-3px) scale(1.03); */ /* Original transform */
+    transform: scale(1.06); /* Adjust scale factor */
+    transform-origin: center bottom; /* Scale from the bottom-center */
     box-shadow: var(--depth-shadow); /* Use existing depth shadow */
 }
 


### PR DESCRIPTION
## Description

This pull request addresses issue #69  where UI elements (navbar links, buttons, cards) flicker when the mouse cursor hovers near their bottom edge.

The flickering was caused by the `translateY()` transform on hover, which would shift the element out from under the cursor, leading to a rapid loop of hover and unhover states.

This PR modifies the CSS for hover effects on the affected elements:
- Replaced the combined `translateY()` and `scale()` transforms with a single `scale()` transform.
- Set `transform-origin: center bottom` for these elements on hover.

This change ensures that the elements scale upwards from their bottom edge, keeping the bottom edge stationary relative to the cursor during the hover animation. This prevents the element from moving out from under the cursor and resolves the flickering issue, providing a smoother and more stable user experience.

## Changes Made

- Updated `app/static/css/style.css`:
    - Modified `.navbar .nav-link:hover`
    - Modified `.btn-primary:hover`
    - Modified `.btn-cyber-primary:hover, .btn-cyber-secondary:hover, .btn-cyber-outline:hover`
    - Modified `.card:hover, .result:hover, .list-group-item:hover`
    - Modified `.report-card:hover`
  to use `transform: scale()` with `transform-origin: center bottom`.

## How to Test

1.  Checkout this branch (`fix/hover-flicker-bottom-edge`).
2.  Run the application.
3.  Navigate to various pages and test the hover effect on the following elements:
    *   Navigation bar links
    *   All primary buttons
    *   All "cyber" styled buttons
    *   General cards and list items
    *   Report cards
4.  Specifically, move the mouse cursor slowly towards the *bottom edge* of these elements.
5.  Verify that the elements now scale up smoothly without any flickering or jittering, and scale down smoothly when the mouse moves away.

## Related Issue

Fixes #69 